### PR TITLE
Update nfc_playlist_scene_emulation.c

### DIFF
--- a/scenes/nfc_playlist_scene_emulation.c
+++ b/scenes/nfc_playlist_scene_emulation.c
@@ -13,11 +13,8 @@ int32_t nfc_playlist_emulation_task(void* context) {
 
    Storage* storage = furi_record_open(RECORD_STORAGE);
    Stream* stream = file_stream_alloc(storage);
-   bool skip_delay = false;
 
-   popup_reset(nfc_playlist->popup);
    popup_set_context(nfc_playlist->popup, nfc_playlist);
-
    view_dispatcher_switch_to_view(nfc_playlist->view_dispatcher, NfcPlaylistView_Popup);
 
    if(nfc_playlist->settings.playlist_length == 0) {
@@ -33,9 +30,9 @@ int32_t nfc_playlist_emulation_task(void* context) {
 
       bool delay_setting_on = nfc_playlist->settings.emulate_delay > 0;
       bool delay_active = false;
+      bool skip_delay = false;
 
       while(stream_read_line(stream, line) && EmulationState == NfcPlaylistEmulationState_Emulating) {
-
          furi_string_trim(line);
 
          if(furi_string_empty(line)) {
@@ -62,7 +59,6 @@ int32_t nfc_playlist_emulation_task(void* context) {
 
          if(EmulationState != NfcPlaylistEmulationState_Emulating) {break;}
 
-         char* file_path = (char*)furi_string_get_cstr(line);
          path_extract_filename(line, tmp_file_name, false);
          path_extract_ext_str(line, tmp_file_ext);
 
@@ -82,7 +78,7 @@ int32_t nfc_playlist_emulation_task(void* context) {
                furi_delay_ms(50);
                time_counter_ms -= 50;
             };
-         } else if(!storage_file_exists(storage, file_path)) {
+         } else if(!storage_file_exists(storage, furi_string_get_cstr(line))) {
             if(nfc_playlist->settings.skip_error) {
                skip_delay = true;
                continue;
@@ -99,7 +95,7 @@ int32_t nfc_playlist_emulation_task(void* context) {
          } else {
             furi_string_printf(tmp_header_str, "Emulating:\n%s", furi_string_get_cstr(tmp_file_name));
             popup_set_header(nfc_playlist->popup, furi_string_get_cstr(tmp_header_str), 64, 10, AlignCenter, AlignTop);
-            nfc_playlist_emulation_worker_set_nfc_data(nfc_playlist->nfc_playlist_emulation_worker, file_path);
+            nfc_playlist_emulation_worker_set_nfc_data(nfc_playlist->nfc_playlist_emulation_worker, (char*)furi_string_get_cstr(line));
             nfc_playlist_emulation_worker_start(nfc_playlist->nfc_playlist_emulation_worker);
             start_blink(nfc_playlist, NfcPlaylistLedState_Normal);
             while(nfc_playlist_emulation_worker_is_emulating(nfc_playlist->nfc_playlist_emulation_worker) && time_counter_ms > 0 && EmulationState == NfcPlaylistEmulationState_Emulating) {


### PR DESCRIPTION
- Makes it so the items file path is no longer stored and instead called when needed
- Removes a reset function which is not required
- Moves a setting declaration to within a if statement so that its only created when its needed
- Removes some blank spaces