### PR TITLE
Allow delay up to 12s

### DIFF
--- a/nfc_playlist.h
+++ b/nfc_playlist.h
@@ -71,7 +71,7 @@ typedef struct {
 
 static const int options_emulate_timeout[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 static const int default_emulate_timeout = 4;
-static const int options_emulate_delay[] = {0, 1, 2, 3, 4, 5, 6};
+static const int options_emulate_delay[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 static const int default_emulate_delay = 0;
 static const bool default_emulate_led_indicator = true;
 static const bool default_skip_error = false;

--- a/nfc_playlist.h
+++ b/nfc_playlist.h
@@ -71,7 +71,7 @@ typedef struct {
 
 static const int options_emulate_timeout[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 static const int default_emulate_timeout = 4;
-static const int options_emulate_delay[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+static const int options_emulate_delay[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 static const int default_emulate_delay = 0;
 static const bool default_emulate_led_indicator = true;
 static const bool default_skip_error = false;


### PR DESCRIPTION
I use this app but need a longer delay for my NFC device to prevent lockout.