### PR TITLE
Emulation checks

### DIFF
--- a/application.fam
+++ b/application.fam
@@ -8,7 +8,7 @@ App(
     fap_category="NFC",
     fap_author="@acegoal07",
     fap_weburl="https://github.com/acegoal07/FlipperZero_NFC_Playlist/tree/main",
-    fap_version="2.7",
+    fap_version="2.8",
     fap_icon_assets="assets",
     fap_icon="assets/Playlist_10px.png",
     fap_private_libs=[

--- a/lib/emulation_worker/nfc_playlist_emulation_worker.c
+++ b/lib/emulation_worker/nfc_playlist_emulation_worker.c
@@ -68,17 +68,26 @@ bool nfc_playlist_emulation_worker_is_emulating(
    return nfc_playlist_emulation_worker->state == NfcPlaylistEmulationWorkerState_Emulating;
 }
 
-void nfc_playlist_emulation_worker_set_nfc_data(
+bool nfc_playlist_emulation_worker_set_nfc_data(
    NfcPlaylistEmulationWorker* nfc_playlist_emulation_worker,
    char* file_path) {
    furi_assert(nfc_playlist_emulation_worker);
-   nfc_device_load(nfc_playlist_emulation_worker->nfc_device, file_path);
-   nfc_playlist_emulation_worker->nfc_protocol =
-      nfc_device_get_protocol(nfc_playlist_emulation_worker->nfc_device);
+   if(nfc_device_load(nfc_playlist_emulation_worker->nfc_device, file_path)) {
+      nfc_playlist_emulation_worker->nfc_protocol =
+         nfc_device_get_protocol(nfc_playlist_emulation_worker->nfc_device);
+      return true;
+   }
+   return false;
 }
 
 void nfc_playlist_emulation_worker_clear_nfc_data(
    NfcPlaylistEmulationWorker* nfc_playlist_emulation_worker) {
    furi_assert(nfc_playlist_emulation_worker);
    nfc_device_clear(nfc_playlist_emulation_worker->nfc_device);
+}
+
+bool nfc_playlist_emulation_worker_valid_protocol(
+   NfcPlaylistEmulationWorker* nfc_playlist_emulation_worker) {
+   furi_assert(nfc_playlist_emulation_worker);
+   return nfc_playlist_emulation_worker->nfc_protocol != NfcProtocolInvalid;
 }

--- a/lib/emulation_worker/nfc_playlist_emulation_worker.h
+++ b/lib/emulation_worker/nfc_playlist_emulation_worker.h
@@ -28,8 +28,10 @@ int32_t nfc_playlist_emulation_worker_task(void* context);
 
 bool nfc_playlist_emulation_worker_is_emulating(
    NfcPlaylistEmulationWorker* nfc_playlist_emulation_worker);
-void nfc_playlist_emulation_worker_set_nfc_data(
+bool nfc_playlist_emulation_worker_set_nfc_data(
    NfcPlaylistEmulationWorker* nfc_playlist_emulation_worker,
    char* file_path);
 void nfc_playlist_emulation_worker_clear_nfc_data(
+   NfcPlaylistEmulationWorker* nfc_playlist_emulation_worker);
+bool nfc_playlist_emulation_worker_valid_protocol(
    NfcPlaylistEmulationWorker* nfc_playlist_emulation_worker);

--- a/scenes/nfc_playlist_scene_emulation.c
+++ b/scenes/nfc_playlist_scene_emulation.c
@@ -22,7 +22,7 @@ int32_t nfc_playlist_emulation_task(void* context) {
          nfc_playlist->popup,
          "The playlist you have\nselected is empty",
          64,
-         10,
+         5,
          AlignCenter,
          AlignTop);
    } else if(file_stream_open(
@@ -52,7 +52,7 @@ int32_t nfc_playlist_emulation_task(void* context) {
 
          if(delay_setting_on) {
             if(delay_active && !skip_delay) {
-               popup_set_header(nfc_playlist->popup, "Delaying", 64, 10, AlignCenter, AlignTop);
+               popup_set_header(nfc_playlist->popup, "Delaying", 64, 5, AlignCenter, AlignTop);
                start_blink(nfc_playlist, NfcPlaylistLedState_Error);
                int time_counter_delay_ms =
                   (options_emulate_delay[nfc_playlist->settings.emulate_delay] * 1000);
@@ -87,6 +87,7 @@ int32_t nfc_playlist_emulation_task(void* context) {
             (options_emulate_timeout[nfc_playlist->settings.emulate_timeout] * 1000);
 
          if(furi_string_cmpi_str(tmp_file_ext, ".nfc") != 0) {
+            // Invalid file type error
             if(nfc_playlist->settings.skip_error) {
                skip_delay = true;
                continue;
@@ -99,7 +100,7 @@ int32_t nfc_playlist_emulation_task(void* context) {
                nfc_playlist->popup,
                furi_string_get_cstr(tmp_header_str),
                64,
-               10,
+               5,
                AlignCenter,
                AlignTop);
             start_blink(nfc_playlist, NfcPlaylistLedState_Error);
@@ -116,6 +117,7 @@ int32_t nfc_playlist_emulation_task(void* context) {
                time_counter_ms -= 50;
             };
          } else if(!storage_file_exists(storage, furi_string_get_cstr(line))) {
+            // File not found error
             if(nfc_playlist->settings.skip_error) {
                skip_delay = true;
                continue;
@@ -126,7 +128,7 @@ int32_t nfc_playlist_emulation_task(void* context) {
                nfc_playlist->popup,
                furi_string_get_cstr(tmp_header_str),
                64,
-               10,
+               5,
                AlignCenter,
                AlignTop);
             start_blink(nfc_playlist, NfcPlaylistLedState_Error);
@@ -143,36 +145,107 @@ int32_t nfc_playlist_emulation_task(void* context) {
                time_counter_ms -= 50;
             };
          } else {
-            furi_string_printf(
-               tmp_header_str, "Emulating:\n%s", furi_string_get_cstr(tmp_file_name));
-            popup_set_header(
-               nfc_playlist->popup,
-               furi_string_get_cstr(tmp_header_str),
-               64,
-               10,
-               AlignCenter,
-               AlignTop);
-            nfc_playlist_emulation_worker_set_nfc_data(
-               nfc_playlist->nfc_playlist_emulation_worker, (char*)furi_string_get_cstr(line));
-            nfc_playlist_emulation_worker_start(nfc_playlist->nfc_playlist_emulation_worker);
-            start_blink(nfc_playlist, NfcPlaylistLedState_Normal);
-            while(nfc_playlist_emulation_worker_is_emulating(
-                     nfc_playlist->nfc_playlist_emulation_worker) &&
-                  time_counter_ms > 0 && EmulationState == NfcPlaylistEmulationState_Emulating) {
-               furi_string_printf(tmp_counter_str, "%ds", (time_counter_ms / 1000));
-               popup_set_text(
+            if(nfc_playlist_emulation_worker_set_nfc_data(
+                  nfc_playlist->nfc_playlist_emulation_worker,
+                  (char*)furi_string_get_cstr(line))) {
+               if(nfc_playlist_emulation_worker_valid_protocol(
+                     nfc_playlist->nfc_playlist_emulation_worker)) {
+                  // Emulate NFC data
+                  furi_string_printf(
+                     tmp_header_str, "Emulating:\n%s", furi_string_get_cstr(tmp_file_name));
+                  popup_set_header(
+                     nfc_playlist->popup,
+                     furi_string_get_cstr(tmp_header_str),
+                     64,
+                     5,
+                     AlignCenter,
+                     AlignTop);
+                  nfc_playlist_emulation_worker_start(nfc_playlist->nfc_playlist_emulation_worker);
+                  start_blink(nfc_playlist, NfcPlaylistLedState_Normal);
+                  while(nfc_playlist_emulation_worker_is_emulating(
+                           nfc_playlist->nfc_playlist_emulation_worker) &&
+                        time_counter_ms > 0 &&
+                        EmulationState == NfcPlaylistEmulationState_Emulating) {
+                     furi_string_printf(tmp_counter_str, "%ds", (time_counter_ms / 1000));
+                     popup_set_text(
+                        nfc_playlist->popup,
+                        furi_string_get_cstr(tmp_counter_str),
+                        64,
+                        50,
+                        AlignCenter,
+                        AlignTop);
+                     furi_delay_ms(50);
+                     time_counter_ms -= 50;
+                  };
+                  nfc_playlist_emulation_worker_stop(nfc_playlist->nfc_playlist_emulation_worker);
+                  nfc_playlist_emulation_worker_clear_nfc_data(
+                     nfc_playlist->nfc_playlist_emulation_worker);
+               } else {
+                  // Invalid NFC protocol error
+                  nfc_playlist_emulation_worker_clear_nfc_data(
+                     nfc_playlist->nfc_playlist_emulation_worker);
+                  if(nfc_playlist->settings.skip_error) {
+                     skip_delay = true;
+                     continue;
+                  }
+                  furi_string_printf(
+                     tmp_header_str,
+                     "ERROR invalid\nNFC protocol:\n%s",
+                     furi_string_get_cstr(tmp_file_name));
+                  popup_set_header(
+                     nfc_playlist->popup,
+                     furi_string_get_cstr(tmp_header_str),
+                     64,
+                     5,
+                     AlignCenter,
+                     AlignTop);
+                  start_blink(nfc_playlist, NfcPlaylistLedState_Error);
+                  while(time_counter_ms > 0 &&
+                        EmulationState == NfcPlaylistEmulationState_Emulating) {
+                     furi_string_printf(tmp_counter_str, "%ds", (time_counter_ms / 1000));
+                     popup_set_text(
+                        nfc_playlist->popup,
+                        furi_string_get_cstr(tmp_counter_str),
+                        64,
+                        50,
+                        AlignCenter,
+                        AlignTop);
+                     furi_delay_ms(50);
+                     time_counter_ms -= 50;
+                  };
+               }
+            } else {
+               // Failed to load NFC data error
+               if(nfc_playlist->settings.skip_error) {
+                  skip_delay = true;
+                  continue;
+               }
+               furi_string_printf(
+                  tmp_header_str,
+                  "ERROR failed to\nload NFC data:\n%s",
+                  furi_string_get_cstr(tmp_file_name));
+               popup_set_header(
                   nfc_playlist->popup,
-                  furi_string_get_cstr(tmp_counter_str),
+                  furi_string_get_cstr(tmp_header_str),
                   64,
-                  50,
+                  5,
                   AlignCenter,
                   AlignTop);
-               furi_delay_ms(50);
-               time_counter_ms -= 50;
-            };
-            nfc_playlist_emulation_worker_stop(nfc_playlist->nfc_playlist_emulation_worker);
-            nfc_playlist_emulation_worker_clear_nfc_data(
-               nfc_playlist->nfc_playlist_emulation_worker);
+               start_blink(nfc_playlist, NfcPlaylistLedState_Error);
+               while(time_counter_ms > 0 &&
+                     EmulationState == NfcPlaylistEmulationState_Emulating) {
+                  furi_string_printf(tmp_counter_str, "%ds", (time_counter_ms / 1000));
+                  popup_set_text(
+                     nfc_playlist->popup,
+                     furi_string_get_cstr(tmp_counter_str),
+                     64,
+                     50,
+                     AlignCenter,
+                     AlignTop);
+                  furi_delay_ms(50);
+                  time_counter_ms -= 50;
+               };
+            }
          }
       }
       stop_blink(nfc_playlist);
@@ -190,12 +263,12 @@ int32_t nfc_playlist_emulation_task(void* context) {
          EmulationState == NfcPlaylistEmulationState_Canceled ? "Emulation stopped" :
                                                                 "Emulation finished",
          64,
-         10,
+         5,
          AlignCenter,
          AlignTop);
    } else {
       popup_set_header(
-         nfc_playlist->popup, "Failed to open playlist", 64, 10, AlignCenter, AlignTop);
+         nfc_playlist->popup, "Failed to open playlist", 64, 5, AlignCenter, AlignTop);
    }
    popup_set_text(nfc_playlist->popup, "Press back", 64, 50, AlignCenter, AlignTop);
 


### PR DESCRIPTION
- Adds 2 checks to the emulation worker to be used in the emulation screen to detect any nfc cards being unable to load and to also detect for an invalid protocol